### PR TITLE
ReadMe suggested change

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pip install .
 ```
 cd ..    # ./Deep3DFaceRecon_pytorch
 git clone https://github.com/deepinsight/insightface.git
-cp -r ./insightface/recognition/arcface_torch/ ./models/
+cp -r ./insightface/recognition/arcface_torch ./models/
 ```
 ## Inference with a pre-trained model
 


### PR DESCRIPTION
Nit:
I've noticed that we intend to copy the `arcface_torch` folder into our models folder. However the current cp syntax will copy all files in arcface_torch into ./models, potentially overriding files where they exist. This also produces a python error where the `arcface_torch` directory cannot be found. The solution is to remove the trailing `/` to just copy the directory and not the underlying files.