### PR TITLE
fix: specify nvdiffrast version as v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ source activate deep3d_pytorch
 
 2. Install Nvdiffrast library:
 ```
-git clone https://github.com/NVlabs/nvdiffrast
+git clone -b 0.3.0 https://github.com/NVlabs/nvdiffrast
 cd nvdiffrast    # ./Deep3DFaceRecon_pytorch/nvdiffrast
 pip install .
 ```


### PR DESCRIPTION
Hello, this is a very good work. Your work has been widely used in the field of Audio-driven Talking Head Generation this year to test an indicator called E-FID. "EMO: Emote Portrait Alive - Generating Expressive Portrait Videos with Audio2Video Diffusion Model under Weak Conditions".
When I used this repository to test this indicator, I found an error that may occur during configuration after Jun 30, 2023.

There are three lines of commands in the repository's README.md:
```
git clone https://github.com/NVlabs/nvdiffrast
cd nvdiffrast
pip install . 
```

The README was updated on May 26, 2023, when the repository link pointed to nvdiffrast version v0.3.0. Now that the nvdiffrast repository has been updated since Jun 30, 2023, using other environments originally specified in the repository in combination with new version nvdiffrast will cause errors in compiling nvdiffrast_plugin. 
Therefore, the corresponding nvdiffrast version should be strictly specified in the README. The correct configuration command should be：
```
git clone -b v0.3.0 https://github.com/NVlabs/nvdiffrast
cd nvdiffrast
pip install . 
```

